### PR TITLE
Initial v1 action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,35 @@
+name: Test action
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test-new-version:
+    name: Test action (recent version)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup-cue
+      uses: ./
+      with:
+        version: 0.4.0
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - run: cue version | grep 0.4.0
+  test-old-version:
+    name: Test action (older version)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup-cue
+      uses: ./
+      with:
+        version: 0.2.1
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - run: cue version | grep 0.2.1

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# setup-cue
-Setup cuelang in your GitHub Actions workflow
+# Setup CUE
+
+This GitHub Action downloads and installs [`cue`](https://cuelang.org/) so that
+it can be used as part of your workflow.
+
+## Inputs
+
+### `version`
+
+Exact version of `cue` to install (cannot be a range or pattern).
+Must be a [released version](https://github.com/cuelang/cue/releases).
+
+### `github-token`
+
+GitHub Token to use when downloading the release from GitHub.
+
+## Outputs
+
+### `bin`
+
+Path to the `cue` binary, but will also be made available in `$GITHUB_PATH`.
+
+## Example usage
+
+```yaml
+permissions:
+  contents: read
+steps:
+- uses: sajari/setup-cue@v1
+  with:
+    version: 0.4.0
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+- run: cue version
+```

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,32 @@
+name: 'setup-cue'
+description: 'Sets up an environment with CUE'
+inputs:
+  version:
+    description: 'cue version, must be an exact version not a range or pattern'
+    required: true
+  github-token:
+    description: 'GitHub Token to use when downloading GitHub releases'
+    required: true
+outputs:
+  bin:
+    description: 'path to cue binary'
+    value: ${{ steps.download.outputs.bin }}
+runs:
+  using: "composite"
+  steps:
+  - id: download
+    shell: bash
+    env:
+      GITHUB_TOKEN: "${{ inputs.github-token }}"
+    run: |-
+      CUE_BIN_DIR="${{ runner.tool_cache }}/cue/${{ inputs.version }}/bin"
+      gh release download \
+        -D ${{ runner.temp }} \
+        -R cuelang/cue \
+        -p "cue_${{ inputs.version }}_${RUNNER_OS}_x86_64.tar.gz" \
+        -p "cue_v${{ inputs.version }}_${RUNNER_OS,,}_amd64.tar.gz" \
+        v${{ inputs.version }}
+      mkdir -p "${CUE_BIN_DIR}"
+      tar xzf ${{ runner.temp }}/cue*.tar.gz -C "${CUE_BIN_DIR}" cue
+      echo "::set-output name=bin::${CUE_BIN_DIR}/cue"
+      echo "${CUE_BIN_DIR}" >> "${GITHUB_PATH}"


### PR DESCRIPTION
Implemented as a composite action and uses `gh` to do the heavy lifting.

The cue project changed the artifact naming convention after v0.3.0, so
we must supply multiple patterns to `gh release download` in order to
support older versions too.