### PR TITLE
fix(gh): remove set-output warning

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -28,5 +28,5 @@ runs:
         v${{ inputs.version }}
       mkdir -p "${CUE_BIN_DIR}"
       tar xzf ${{ runner.temp }}/cue*.tar.gz -C "${CUE_BIN_DIR}" cue
-      echo "::set-output name=bin::${CUE_BIN_DIR}/cue"
+      echo "bin=${CUE_BIN_DIR}/cue" >> $GITHUB_OUTPUT
       echo "${CUE_BIN_DIR}" >> "${GITHUB_PATH}"


### PR DESCRIPTION
This PR remove a warning in the Github Action run about set-output deprecation.
I followed [this blogpost](https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/).